### PR TITLE
Update entrypoint.sh - fix invalid count

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,8 +8,8 @@ if [ -z "$outdated" ];
 then
   message="Congratulations, all your dependencies have the latest releases! 🥳"
 else
-  outdated=$(echo "$outdated" | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g')
   countOutdated=$(echo "$outdated" | wc -l)
+  outdated=$(echo "$outdated" | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g')
   message="**You have $countOutdated dependencies with newer available releases:**\n$outdated"
 fi
 


### PR DESCRIPTION
Update entrypoint.sh - fix invalid count
Calculate count of outdated _before_ reformatting

Here is some testing I did locally:

Before reformatting:
```
protobuf-kotlin 3.23.2 => 3.23.3
launchdarkly-java-server-sdk 6.1.0 => 6.2.0
bcprov-jdk18on 1.73 => 1.74
```

After reformatting:
`protobuf-kotlin 3.23.2 => 3.23.3\nlaunchdarkly-java-server-sdk 6.1.0 => 6.2.0\nbcprov-jdk18on 1.73 => 1.74`

Updated message:
`**You have 3 dependencies with newer available releases:**\nprotobuf-kotlin 3.23.2 => 3.23.3\nlaunchdarkly-java-server-sdk 6.1.0 => 6.2.0\nbcprov-jdk18on 1.73 => 1.74
`